### PR TITLE
fix: correct fallback to default cluster placeholder on create table

### DIFF
--- a/pkg/resources/table/resource_table.go
+++ b/pkg/resources/table/resource_table.go
@@ -182,7 +182,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 	tableResource.OrderBy = common.MapArrayInterfaceToArrayOfStrings(d.Get("order_by").([]interface{}))
 	tableResource.SetPartitionBy(d.Get("partition_by").([]interface{}))
 
-	if tableResource.Cluster != "" {
+	if tableResource.Cluster == "" {
 		tableResource.Cluster = client.DefaultCluster
 	}
 


### PR DESCRIPTION
Bug at create table resource if empty cluster name at provider