### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,18 +16,18 @@ description: |-
 terraform {
   required_providers {
     clickhouse = {
-      version = "2.0.0"
-      source  = "hashicorp.com/ivanofthings/clickhouse"
+      version = "3.0.1"
+      source  = "IvanOfThings/clickhouse"
     }
   }
 }
 
 
 provider "clickhouse" {
-  port           = 8123
-  clickhouse_url = "127.0.0.1"
-  username       = "default"
-  password       = ""
+  port     = 8123
+  host     = "127.0.0.1"
+  username = "default"
+  password = ""
 }
 ```
 


### PR DESCRIPTION
Update provider parameters:
- The latest version is `3.0.1`
- Using `hashicorp.com` returns an error
- `clickhouse_url` does not exist in favor of `host`