### PR TITLE
:sparkles: allow global privileges, only for 'REMOTE' at the moment

### DIFF
--- a/pkg/resources/role/resource_role.go
+++ b/pkg/resources/role/resource_role.go
@@ -48,7 +48,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	planDatabase := d.Get("database").(string)
 	planPrivileges := d.Get("privileges").(*schema.Set)
 
-	diags = ValidatePrivileges(planPrivileges)
+	diags = ValidatePrivileges(planDatabase, planPrivileges)
 
 	if diags.HasError() {
 		return diags
@@ -108,7 +108,7 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 	roleName := d.Get("name").(string)
 	privileges := d.Get("privileges").(*schema.Set)
 
-	diags = ValidatePrivileges(privileges)
+	diags = ValidatePrivileges(database, privileges)
 	if diags.HasError() {
 		return diags
 	}

--- a/pkg/resources/role/resource_role_acceptance_test.go
+++ b/pkg/resources/role/resource_role_acceptance_test.go
@@ -74,19 +74,19 @@ var test1StepsData = []TestStepData{
 		// Check all allowed privileges
 		roleName:   roleName1,
 		database:   databaseName1,
-		privileges: resourcerole.AllowedPrivileges,
+		privileges: resourcerole.AllowedDbLevelPrivileges,
 	},
 	{
 		// Change role name
 		roleName:   roleName2,
 		database:   databaseName1,
-		privileges: resourcerole.AllowedPrivileges,
+		privileges: resourcerole.AllowedDbLevelPrivileges,
 	},
 	{
 		// Change role name and db
 		roleName:   roleName1,
 		database:   databaseName2,
-		privileges: resourcerole.AllowedPrivileges,
+		privileges: resourcerole.AllowedDbLevelPrivileges,
 	},
 	{
 		// Change role name, db and privileges
@@ -128,19 +128,25 @@ var test2StepsData = []TestStepData{
 		// Check all allowed privileges
 		roleName:   roleName1,
 		database:   "system",
-		privileges: resourcerole.AllowedPrivileges,
+		privileges: resourcerole.AllowedDbLevelPrivileges,
 	},
 	{
 		// Change role name
 		roleName:   roleName2,
 		database:   "system",
-		privileges: resourcerole.AllowedPrivileges,
+		privileges: resourcerole.AllowedDbLevelPrivileges,
 	},
 }
 
 func generateTestSteps(testStepsData []TestStepData) []resource.TestStep {
 	var testSteps []resource.TestStep
 	for _, testStepData := range testStepsData {
+		var databaseRegex *regexp.Regexp
+		if testStepData.database == "*" {
+			databaseRegex = regexp.MustCompile("\\*")
+		} else {
+			databaseRegex = regexp.MustCompile(testStepData.database)
+		}
 		testSteps = append(testSteps, resource.TestStep{
 			Config: testAccRoleResource(
 				testStepData.roleName,
@@ -156,7 +162,7 @@ func generateTestSteps(testStepsData []TestStepData) []resource.TestStep {
 				resource.TestMatchResourceAttr(
 					roleResource,
 					"database",
-					regexp.MustCompile(testStepData.database),
+					databaseRegex,
 				),
 				testutils.CheckStateSetAttr("privileges", roleResource, testStepData.privileges),
 				testAccCheckRoleResourceExists(testStepData.roleName, testStepData.database, testStepData.privileges),
@@ -180,6 +186,20 @@ func TestAccResourceRole(t *testing.T) {
 		CheckDestroy: testAccCheckRoleResourceDestroy([]string{roleName1, roleName2}),
 		Steps:        generateTestSteps(test2StepsData),
 	})
+	// Feature tests, global privileges
+	resource.Test(t, resource.TestCase{
+		Providers:    testutils.Provider(),
+		CheckDestroy: testAccCheckRoleResourceDestroy([]string{roleName1, roleName2}),
+		Steps: generateTestSteps([]TestStepData{
+			{
+				// Create role
+				roleName: roleName1,
+				database: "*",
+				privileges: []string{
+					"REMOTE",
+				},
+			}}),
+	})
 	// Validate privileges on create
 	resource.Test(t, resource.TestCase{
 		Providers: testutils.Provider(),
@@ -191,6 +211,19 @@ func TestAccResourceRole(t *testing.T) {
 					common.Quote([]string{"NOT_ALLOWED_PRIVILEGE"}),
 				),
 				ExpectError: regexp.MustCompile("NOT_ALLOWED_PRIVILEGE isn't in the allowed privileges list"),
+			},
+		},
+	})
+	resource.Test(t, resource.TestCase{
+		Providers: testutils.Provider(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleResource(
+					roleName1,
+					databaseName1,
+					common.Quote([]string{"REMOTE"}),
+				),
+				ExpectError: regexp.MustCompile("Global privilege REMOTE is only allowed for database '\\*'"),
 			},
 		},
 	})
@@ -224,6 +257,15 @@ func testAccRoleResource(roleName string, database string, privileges []string) 
 	resource "clickhouse_role" "test_role" {
 		name = "%s"
 		database = "system"
+		privileges = [%s]
+	}`, roleName, strings.Join(privileges, ","))
+	}
+
+	if database == "*" {
+		return fmt.Sprintf(`
+	resource "clickhouse_role" "test_role" {
+		name = "%s"
+		database = "*"
 		privileges = [%s]
 	}`, roleName, strings.Join(privileges, ","))
 	}

--- a/pkg/resources/role/service.go
+++ b/pkg/resources/role/service.go
@@ -13,7 +13,7 @@ type CHRoleService struct {
 }
 
 func getGrantQuery(roleName string, privileges []string, database string) string {
-	if database == "system" {
+	if database == "system" || database == "*" {
 		return fmt.Sprintf("GRANT CURRENT GRANTS (%s ON %s.*) TO %s", strings.Join(privileges, ","), database, roleName)
 	}
 	return fmt.Sprintf("GRANT %s ON %s.* TO %s", strings.Join(privileges, ","), database, roleName)
@@ -33,6 +33,9 @@ func (rs *CHRoleService) getRoleGrants(ctx context.Context, roleName string) ([]
 		err := rows.ScanStruct(&privilege)
 		if err != nil {
 			return nil, fmt.Errorf("error scanning role grant: %s", err)
+		}
+		if privilege.Database == "" {
+			privilege.Database = "*"
 		}
 		privileges = append(privileges, privilege)
 	}


### PR DESCRIPTION
This PR allows to set `database = "*"` when you create a new role. The purpose of this is be able of grant global privileges as "REMOTE". It also allows to grant any other privilege to all databases.