### PR TITLE
Added SYSTEM FLUSH to allowed DbLvelPriviledges

### DIFF
--- a/pkg/resources/role/validators.go
+++ b/pkg/resources/role/validators.go
@@ -20,6 +20,7 @@ var AllowedDbLevelPrivileges = []string{
 	"DROP DICTIONARY",
 	"DROP VIEW",
 	"SHOW TABLES",
+	"SYSTEM FLUSH",
 	"dictGet",
 }
 


### PR DESCRIPTION
This pull request introduces a small update to the `AllowedDbLevelPrivileges` list in `pkg/resources/role/validators.go`. The change adds the "SYSTEM FLUSH" privilege to the list of allowed database-level privileges.